### PR TITLE
feat: Elasticsearch 인덱싱 및 테스트 스크립트 추가

### DIFF
--- a/ai/preprocessing/4_index.py
+++ b/ai/preprocessing/4_index.py
@@ -1,0 +1,132 @@
+import os
+import json
+from elasticsearch import Elasticsearch, helpers
+from tqdm import tqdm # 진행률 표시
+
+# --- 설정 ---
+# 1. Elasticsearch 연결
+es = Elasticsearch("http://localhost:9200")
+
+# 2. 인덱스 이름 정의
+INDEX_NAME = "docscanner_chunks"
+
+# 3. 인덱싱할 데이터 파일 경로
+DATA_FILES = [
+    "../data/processed/embeddings/legal_chunks_with_embeddings_20251027.json",
+    "../data/processed/embeddings/chunks_with_embeddings.json"
+]
+# -----------------
+
+def create_index():
+    """Elasticsearch 인덱스 생성. (테이블 스키마 정의)"""
+    
+    # BM25(nori) 및 벡터 검색(1024차원)을 위한 매핑 설정
+    index_settings = {
+        "mappings": {
+            "properties": {
+                "text": {  # (중요!) ES에 저장될 필드 이름은 'text'
+                    "type": "text",
+                    "analyzer": "nori"  # 한국어 형태소 분석기
+                },
+                "embedding": {
+                    "type": "dense_vector",
+                    "dims": 1024  # KURE-v1 벡터 차원
+                },
+                "source": {
+                    "type": "keyword" # 필터링용 출처
+                }
+            }
+        }
+    }
+
+    if not es.indices.exists(index=INDEX_NAME):
+        print(f"'{INDEX_NAME}' 인덱스 생성 시도...")
+        es.indices.create(index=INDEX_NAME, body=index_settings)
+        print("인덱스 생성 완료.")
+    else:
+        print(f"'{INDEX_NAME}' 인덱스가 이미 존재함.")
+
+
+def load_data():
+    """DATA_FILES 목록의 JSON 파일 로드"""
+    all_data = []
+    for file_path in DATA_FILES:
+        # 파일 존재 여부 확인
+        if not os.path.exists(file_path):
+            print(f"경고: {file_path} 파일을 찾을 수 없음. 건너뜀.")
+            continue
+            
+        print(f"{file_path} 로드 중...")
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                all_data.extend(data) # 단일 리스트로 병합
+        except Exception as e:
+            print(f"파일 로드 오류: {e}")
+
+    print(f"총 {len(all_data)}개 데이터 로드 완료.")
+    return all_data
+
+def generate_actions(data):
+    """(!!! 핵심 수정 !!!) Elasticsearch Bulk API용 데이터 형식 생성 (yield)"""
+    print("Bulk API 형식으로 데이터 변환...")
+    
+    # (!!! 수정됨 !!!) 'content' 키를 사용하고 'source' 키는 파일 구조에 맞게 처리
+    for item in tqdm(data):
+        # 1. 필수 키('content', 'embedding') 확인
+        if 'content' not in item or 'embedding' not in item:
+            print(f"경고: 데이터 형식 오류 (필수 키 'content' 또는 'embedding' 누락). 건너뜀.")
+            continue
+        
+        # 2. 'source' 키 확인 (파일마다 구조가 다름)
+        source_value = "unknown" # 기본값
+        if 'source' in item:
+            source_value = item['source']      # chunks_...json 파일용
+        elif 'doc_type' in item:
+            source_value = item['doc_type']  # legal_...json 파일용
+            
+        yield {
+            "_index": INDEX_NAME,
+            "_source": {
+                "text": item["content"],     # JSON의 'content'를 ES의 'text' 필드로 매핑
+                "embedding": item["embedding"],
+                "source": source_value       # 찾은 'source' 또는 'doc_type' 값을 사용
+            }
+        }
+
+def main():
+    """메인 인덱싱 파이프라인 실행"""
+    
+    # 0. ES 연결 상태 확인
+    # if not es.ping():
+    #     print("Elasticsearch 연결 실패. Docker 및 localhost:9200 확인 필요.")
+    #     return
+
+    # 1. 인덱스 생성 (또는 확인)
+    create_index()
+
+    # 2. JSON 데이터 로드
+    all_chunks = load_data()
+    if not all_chunks:
+        print("인덱싱할 데이터 없음. 종료.")
+        return
+
+    # 3. 데이터 인덱싱 (Bulk API)
+    print("Elasticsearch 데이터 인덱싱 시작...")
+    try:
+        success, failed = helpers.bulk(
+            es,
+            generate_actions(all_chunks),
+            chunk_size=500,  # 500개씩 묶어서 전송
+            request_timeout=60
+        )
+        print("="*30)
+        print(f"🎉 인덱싱 완료! 🎉")
+        print(f"성공: {success}개")
+        print(f"실패: {failed}개")
+        print("="*30)
+    except Exception as e:
+        print(f"인덱싱 중 오류 발생: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/ai/preprocessing/test_es_search.py
+++ b/ai/preprocessing/test_es_search.py
@@ -1,0 +1,174 @@
+import os
+import re
+import json
+from elasticsearch import Elasticsearch, helpers
+from sentence_transformers import SentenceTransformer
+
+# --- 설정 ---
+# 1. 쿼리 임베딩 모델 로드
+print("임베딩 모델 로드 중... (KURE-v1)")
+MODEL_NAME = "nlpai-lab/KURE-v1" # search.py에서 확인한 모델 이름
+try:
+    model = SentenceTransformer(MODEL_NAME)
+    model.max_seq_length = 512 # 원본 search.py와 동일하게 설정
+except Exception as e:
+    print(f"모델 로드 실패! '{MODEL_NAME}'이 맞는지 확인하세요. (오류: {e})")
+    print("인터넷 연결을 확인하거나, 모델 이름을 다시 확인하세요.")
+    exit()
+
+# 2. Elasticsearch 연결
+# (터미널에서 set NO_PROXY=localhost를 실행해야 함)
+es = Elasticsearch("http://localhost:9200") 
+
+# 3. 인덱스 이름
+INDEX_NAME = "docscanner_chunks"
+
+# 4. 문서 타입 매핑 (로그 출력용)
+DOC_TYPE_MAP = {
+    'interpretation': '법령해석례',
+    'precedent': '판례',
+    'labor_ministry': '고용노동부',
+    'manual': '매뉴얼(PDF)',
+    'employment_rules': '취업규칙(PDF)',
+    'guide': '안내서(PDF)',
+    'leaflet': '리플릿(PDF)',
+    'question': '질의(법률)',
+    'answer': '답변(법률)',
+}
+# -----------------
+
+def search_es(query: str, top_k: int = 5, filter_source: str = None):
+    """Elasticsearch에 벡터 검색(KNN) 실행 (필터 포함)"""
+    
+    # 1. 사용자 쿼리를 벡터로 변환
+    print("\n쿼리 임베딩 중...")
+    try:
+        query_vector = model.encode(query, normalize_embeddings=True).tolist()
+    except Exception as e:
+        print(f"쿼리 임베딩 실패: {e}")
+        return []
+        
+    print("Elasticsearch로 검색 실행 중...")
+
+    # 2. Elasticsearch KNN 쿼리 생성
+    knn_query = {
+        "field": "embedding",
+        "query_vector": query_vector,
+        "k": top_k,
+        "num_candidates": 100 
+    }
+
+    # 3. 필터가 있다면 KNN 쿼리 내부에 'filter' 블록 추가
+    if filter_source:
+        knn_query["filter"] = {
+            "term": {
+                "source": filter_source 
+            }
+        }
+        print(f"(필터 적용: source == '{filter_source}')")
+
+
+    try:
+        response = es.search(
+            index=INDEX_NAME,
+            knn=knn_query, 
+            size=top_k,
+            request_timeout=30
+        )
+        return response['hits']['hits']
+        
+    except Exception as e:
+        print(f"ES 검색 중 오류 발생: {e}")
+        return []
+
+def main():
+    """사용자 입력을 받아 검색을 수행하는 메인 루프"""
+    if not es.indices.exists(index=INDEX_NAME):
+        print(f"오류: '{INDEX_NAME}' 인덱스를 찾을 수 없습니다.")
+        print("4_index.py를 먼저 실행했는지 확인하세요.")
+        return
+
+    print("\n" + "="*70)
+    print("🎉 Elasticsearch 임베딩 검색 테스트 (대화형 모드)")
+    print("="*70)
+    print("\n사용법:")
+    print("  - 검색: 쿼리 입력")
+    print("  - 필터: @필터명 추가 (예: 최저임금 @precedent)")
+    print("  - 상위 결과: #숫자 추가 (예: 연차 #10)")
+    print("  - 종료: 'q' 또는 'exit' 입력")
+    print("\n사용 가능한 필터 예시:")
+    print("  - @precedent (판례만)")
+    print("  - @interpretation (법령해석례만)")
+    print("  - @manual (매뉴얼만)")
+    print("  - @employment_rules (취업규칙만)")
+    print("="*70 + "\n")
+
+    while True:
+        try:
+            user_input = input("검색 쿼리: ").strip()
+
+            if user_input.lower() in ['q', 'exit', 'quit', '종료']:
+                print("\n테스트를 종료합니다.")
+                break
+            
+            if not user_input:
+                continue
+
+            # --- 파라미터 파싱 ---
+            query = user_input
+            filter_source = None
+            top_k = 5 # 기본 5개
+
+            # 1. @ 필터 파싱
+            if '@' in query:
+                parts = query.split('@')
+                query = parts[0].strip()
+                filter_str = parts[1].strip().split()[0]
+                filter_source = filter_str 
+            
+            # 2. # top_k 파싱
+            if '#' in query:
+                parts = query.split('#')
+                query = parts[0].strip()
+                try:
+                    top_k = int(parts[1].strip().split()[0])
+                    top_k = min(max(top_k, 1), 20) # 1~20개로 제한
+                except ValueError:
+                    print("잘못된 숫자 형식. 기본 5개로 검색합니다.")
+                    top_k = 5
+            
+            if not query:
+                print("검색어가 없습니다.")
+                continue
+
+            # --- ES 검색 실행 ---
+            results = search_es(query, top_k=top_k, filter_source=filter_source)
+
+            if not results:
+                print("\n-> 검색 결과가 없습니다.")
+                print("="*70)
+                continue
+
+            # --- 결과 로그 출력 ---
+            print(f"\n--- '{query}' 검색 결과 (Top {len(results)}) ---")
+            for i, hit in enumerate(results):
+                source_data = hit['_source']
+                source_type = source_data.get('source', 'unknown')
+                
+                print(f"\n[{i+1}] 유사도: {hit['_score']:.4f}")
+                print(f"  (출처 타입: {DOC_TYPE_MAP.get(source_type, source_type)})") # 맵핑된 이름 출력
+                
+                # 내용 미리보기
+                content = source_data.get('text', '').replace('\n', ' ')[:200]
+                print(f"  내용: {content}...")
+                print("-"*20)
+            print("="*70)
+                
+        except KeyboardInterrupt:
+            print("\n테스트를 종료합니다.")
+            break
+        except Exception as e:
+            print(f"!!! 전체 루프 오류 발생: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 1. 작업 내용

RAG 시스템의 검색 엔진 구축을 위해 [Task 2: Elasticsearch 인덱싱]을 완료함.

- 15,223개의 법률/PDF 데이터 조각을 Elasticsearch 8.x DB에 인덱싱함.
- 인덱싱된 DB가 AI 의미 검색 및 필터링을 올바르게 수행하는지 검증함.

## 2. 주요 변경점 (추가된 파일)

### `ai/preprocessing/4_index.py` (인덱싱 스크립트)

- `nori` 분석기(키워드 검색)와 `KURE-v1` 벡터(의미 검색)가 모두 가능한 **하이브리드 인덱스**(`docscanner_chunks`)를 생성함.
- `legal_...json`과 `chunks_...json`의 서로 다른 키(`content`, `source`, `doc_type` 등)를 `text`, `embedding`, `source`라는 통일된 필드로 매핑하여 ES에 저장함.

### `ai/preprocessing/test/test_es_search.py` (ES 검색 테스트 스크립트)

- `4_index.py`로 구축한 Elasticsearch DB를 직접 테스트하는 스크립트임.
- AI 의미 기반 검색(KNN)과 필터링(`@precedent`), 결과 개수 제한(` #3`) 기능을 구현함.

## 3. 🚨 실행 전 필수 세팅

이 코드를 `develop` 브랜치에 병합(Merge)한 뒤, **로컬에서 실행하려면 반드시 추가 세팅이 필요함.**

별도로 공유한 **[Elasticsearch 세팅 및 인덱싱 가이드] (노션에 있음)**를 먼저 확인하고 인덱싱 작업을 진행해야 함.